### PR TITLE
Remove unused Collectors import

### DIFF
--- a/src/main/java/com/burale/tasktracker/TaskManager.java
+++ b/src/main/java/com/burale/tasktracker/TaskManager.java
@@ -9,7 +9,6 @@ import java.io.File;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.*;
-import java.util.stream.Collectors;
 
 public class TaskManager {
     private final File file = new File("tasks.json");


### PR DESCRIPTION
## Summary
- remove unused `Collectors` import

## Testing
- `mvn -q -DskipTests compile` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e47ee06248331a2fa6785f1afff38