### PR TITLE
Accept hyphenated list status in task tracker CLI

### DIFF
--- a/src/main/java/com/burale/tasktracker/Main.java
+++ b/src/main/java/com/burale/tasktracker/Main.java
@@ -79,10 +79,14 @@ public class Main {
                     taskManager.listTasks();
                 } else if (args.length == 2) {
                     try {
-                        Task.Status status = Task.Status.valueOf(args[1].toUpperCase());
+                        String normalizedStatus = args[1].replace('-', '_').toUpperCase();
+                        Task.Status status = Task.Status.valueOf(normalizedStatus);
                         taskManager.listByStatus(status);
                     } catch (IllegalArgumentException e) {
-                        System.out.println("Invalid status. Use: todo, in-progress, done");
+                        String supported = java.util.Arrays.stream(Task.Status.values())
+                                .map(s -> s.name().toLowerCase().replace('_', '-'))
+                                .collect(java.util.stream.Collectors.joining(", "));
+                        System.out.println("Invalid status. Supported options: " + supported);
                     }
                 } else {
                     System.out.println("Usage: task-cli list [status]");


### PR DESCRIPTION
## Summary
- Normalize hyphenated status arguments before parsing in list command
- Show supported statuses when an invalid status is provided

## Testing
- ❌ `mvn -q package` *(Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*
- ⚠️ `java -cp target/classes com.burale.tasktracker.Main list in-progress` *(NoClassDefFoundError: com.fasterxml.jackson.databind.Module)*

------
https://chatgpt.com/codex/tasks/task_e_689e4889789c83318913fe147aa52258