### PR TITLE
docs: clarify task status commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A command-line Java application to track and manage your tasks. This project hel
 ## 🚀 Features
 
 - Add, update, and delete tasks
-- Mark tasks as TODO, IN_PROGRESS, or DONE
+- Mark tasks as IN_PROGRESS or DONE (new tasks start as TODO)
 - List tasks or filter by status
 - Persistent storage using `tasks.json`
 
@@ -33,7 +33,6 @@ java -cp "target\classes;[same classpath]" com.burale.tasktracker.Main mark-in-p
 java -cp "target\classes;[same classpath]" com.burale.tasktracker.Main mark-done 1
 
 # List tasks by status
-java -cp "target\classes;[same classpath]" com.burale.tasktracker.Main list todo
 java -cp "target\classes;[same classpath]" com.burale.tasktracker.Main list done
 java -cp "target\classes;[same classpath]" com.burale.tasktracker.Main list in-progress
 


### PR DESCRIPTION
## Summary
- clarify that tasks can only be marked as in-progress or done
- remove `list todo` example so examples show only `mark-in-progress` and `mark-done`

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e913c1a808331920f13b32c0bb465